### PR TITLE
Import new connection recovery code from swift-rabbitmq

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "sourceLanguages": [
+                "swift"
+            ],
+            "args": [],
+            "cwd": "${workspaceFolder:swift-masstransit}",
+            "name": "Debug PublishConsume",
+            "program": "${workspaceFolder:swift-masstransit}/.build/debug/PublishConsume",
+            "preLaunchTask": "swift: Build Debug PublishConsume"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "sourceLanguages": [
+                "swift"
+            ],
+            "args": [],
+            "cwd": "${workspaceFolder:swift-masstransit}",
+            "name": "Release PublishConsume",
+            "program": "${workspaceFolder:swift-masstransit}/.build/release/PublishConsume",
+            "preLaunchTask": "swift: Build Release PublishConsume"
+        }
+    ]
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,10 +3,19 @@
     {
       "identity" : "rabbitmq-nio",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/funcmike/rabbitmq-nio",
+      "location" : "https://github.com/xtremekforever/rabbitmq-nio",
       "state" : {
-        "revision" : "6a64134229df9bf4f9e5be4eb85a874aa5d3c518",
-        "version" : "0.1.0-beta3"
+        "branch" : "bugfix/46-double-slash-vhost",
+        "revision" : "7b5c384e5175b009775074392a90e42131c1da73"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms",
+      "state" : {
+        "revision" : "6ae9a051f76b81cc668305ceed5b0e0a7fd93d20",
+        "version" : "1.0.1"
       }
     },
     {
@@ -23,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "ee97538f5b81ae89698fd95938896dec5217b148",
-        "version" : "1.1.1"
+        "revision" : "3d2dc41a01f9e49d84f0a3925fb858bed64f702d",
+        "version" : "1.1.2"
       }
     },
     {
@@ -59,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "e5a216ba89deba84356bad9d4c2eab99071c745b",
-        "version" : "2.67.0"
+        "revision" : "e4abde8be0e49dc7d66e6eed651254accdcd9533",
+        "version" : "2.69.0"
       }
     },
     {
@@ -78,7 +87,7 @@
       "location" : "https://github.com/xtremekforever/swift-rabbitmq",
       "state" : {
         "branch" : "main",
-        "revision" : "d47112985264497299351f2075c2fcf1c28b01a0"
+        "revision" : "00588f2248a464572598898ece518a47d3d4f7b7"
       }
     },
     {
@@ -86,8 +95,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-service-context.git",
       "state" : {
-        "revision" : "ce0141c8f123132dbd02fd45fea448018762df1b",
-        "version" : "1.0.0"
+        "revision" : "0c62c5b4601d6c125050b5c3a97f20cce881d32b",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "24c800fb494fbee6e42bc156dc94232dc08971af",
+        "version" : "2.6.1"
       }
     },
     {
@@ -95,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "f9266c85189c2751589a50ea5aec72799797e471",
-        "version" : "1.3.0"
+        "revision" : "d2ba781702a1d8285419c15ee62fd734a9437ff5",
+        "version" : "1.3.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,14 @@ let package = Package(
                 .product(name: "RabbitMq", package: "swift-rabbitmq"),
                 .product(name: "TracingOpenTelemetrySemanticConventions", package: "swift-distributed-tracing-extras"),
             ]
-        )
+        ),
+        .executableTarget(
+            name: "PublishConsume",
+            dependencies: [
+                "MassTransit"
+            ],
+            path: "Sources/Examples/PublishConsume"
+        ),
     ]
 )
 

--- a/Sources/Examples/PublishConsume/PublishConsume.swift
+++ b/Sources/Examples/PublishConsume/PublishConsume.swift
@@ -1,0 +1,53 @@
+import AsyncAlgorithms
+import Foundation
+import Logging
+import MassTransit
+import RabbitMq
+
+struct RabbitMqConnector: Connectable {
+    let connection: Connection
+
+    init(_ connectionUrl: String) throws {
+        self.connection = try Connection(connectionUrl)
+    }
+
+    func getConnection() async -> RabbitMq.Connection? {
+        return connection
+    }
+
+    func run() async throws {
+        try await connection.run(reconnectionInterval: .seconds(15))
+    }
+}
+
+struct MyTestEvent: Codable {
+    let id: UUID
+    let name: String
+}
+
+let logger = Logger(label: "PublishConsume")
+let rabbitMqConnector = try RabbitMqConnector("amqp://guest:guest@localhost/%2F")
+let massTransit = MassTransit(rabbitMqConnector, logger: logger)
+
+let connectTask = Task {
+    try await rabbitMqConnector.run()
+}
+let consumeTask = Task {
+    let events = try await massTransit.consume(MyTestEvent.self)
+    for await event in events {
+        logger.info("Consumed event: \(event)")
+    }
+}
+
+// Start publishing
+for await _ in AsyncTimerSequence(interval: .seconds(1), clock: .continuous) {
+    let event = MyTestEvent(
+        id: UUID(),
+        name: "My Event!"
+    )
+    logger.info("Publishing event: \(event)")
+    try await massTransit.publish(event)
+}
+
+consumeTask.cancel()
+connectTask.cancel()


### PR DESCRIPTION
 - Adopt new functionality while keeping same MassTransit API (adding timeout).
 - Add example app to make it easy to test internal functionality.