### PR TITLE
Use ByteBuffer encoding/decoding with swift-rabbitmq

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xtremekforever/swift-rabbitmq",
       "state" : {
-        "branch" : "14-implement-the-ability-to-publish-and-consume-using-nio-bytebuffers",
-        "revision" : "707fcb45c70d0ba1b7813c06ae428e5512870afa"
+        "branch" : "main",
+        "revision" : "117a75002cad59dbd3d67c3426441892a774a88e"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log",
       "state" : {
-        "revision" : "9cb486020ebf03bfa5b5df985387a14a98744537",
-        "version" : "1.6.1"
+        "revision" : "96a2f8a0fa41e9e09af4585e2724c4e825410b91",
+        "version" : "1.6.2"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "914081701062b11e3bb9e21accc379822621995e",
-        "version" : "2.76.1"
+        "revision" : "dca6594f65308c761a9c409e09fbf35f48d50d34",
+        "version" : "2.77.0"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "d7ceaf0e4d8001cd35cdc12e42cdd281e9e564e8",
-        "version" : "2.28.0"
+        "revision" : "c7e95421334b1068490b5d41314a50e70bab23d1",
+        "version" : "2.29.0"
       }
     },
     {
@@ -96,7 +96,7 @@
       "location" : "https://github.com/xtremekforever/swift-rabbitmq",
       "state" : {
         "branch" : "14-implement-the-ability-to-publish-and-consume-using-nio-bytebuffers",
-        "revision" : "7bc85e016308cfd1e661b7cb955cfcb44506f682"
+        "revision" : "707fcb45c70d0ba1b7813c06ae428e5512870afa"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
       "state" : {
-        "revision" : "24c800fb494fbee6e42bc156dc94232dc08971af",
-        "version" : "2.6.1"
+        "revision" : "f70b838872863396a25694d8b19fe58bcd0b7903",
+        "version" : "2.6.2"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xtremekforever/swift-rabbitmq",
       "state" : {
-        "branch" : "main",
-        "revision" : "04b13702af20a2aed45c2b118faed54693792904"
+        "branch" : "14-implement-the-ability-to-publish-and-consume-using-nio-bytebuffers",
+        "revision" : "7bc85e016308cfd1e661b7cb955cfcb44506f682"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,10 +15,7 @@ let package = Package(
             targets: ["MassTransit"])
     ],
     dependencies: [
-        .package(
-            url: "https://github.com/xtremekforever/swift-rabbitmq",
-            branch: "14-implement-the-ability-to-publish-and-consume-using-nio-bytebuffers"
-        ),
+        .package(url: "https://github.com/xtremekforever/swift-rabbitmq", branch: "main"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.48.0"),
         .package(url: "https://github.com/apple/swift-distributed-tracing-extras.git", from: "1.0.0-beta.1"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,11 @@ let package = Package(
             targets: ["MassTransit"])
     ],
     dependencies: [
-        .package(url: "https://github.com/xtremekforever/swift-rabbitmq", branch: "main"),
+        .package(
+            url: "https://github.com/xtremekforever/swift-rabbitmq",
+            branch: "14-implement-the-ability-to-publish-and-consume-using-nio-bytebuffers"
+        ),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.48.0"),
         .package(url: "https://github.com/apple/swift-distributed-tracing-extras.git", from: "1.0.0-beta.1"),
     ],
     targets: [
@@ -25,6 +29,7 @@ let package = Package(
             name: "MassTransit",
             dependencies: [
                 .product(name: "RabbitMq", package: "swift-rabbitmq"),
+                .product(name: "NIOFoundationCompat", package: "swift-nio"),
                 .product(name: "TracingOpenTelemetrySemanticConventions", package: "swift-distributed-tracing-extras"),
             ]
         ),

--- a/Sources/MassTransit/MassTransit.swift
+++ b/Sources/MassTransit/MassTransit.swift
@@ -95,11 +95,11 @@ public struct MassTransit: Sendable {
 
         // Consume messages with span tracing
         logger.info("Consuming messages of type \(T.self) on queue \(queueName)...")
-        let consumeStream = try await consumer.retryingConsume(retryInterval: retryInterval)
+        let consumeStream = try await consumer.retryingConsumeBuffer(retryInterval: retryInterval)
         return AnyAsyncSequence<T>(
-            consumeStream.compactMap { message in
+            consumeStream.compactMap { buffer in
                 return try withSpan("\(T.self) consume", ofKind: .consumer) { span in
-                    let wrapper = try MassTransitWrapper(T.self, from: message)
+                    let wrapper = try MassTransitWrapper(T.self, from: buffer)
 
                     // Log!
                     logger.debug("Consumed message \(wrapper.message) from queue \(queueName)")
@@ -129,11 +129,11 @@ public struct MassTransit: Sendable {
 
         // Consume messages with span tracing
         logger.info("Consuming messages of type \(T.self) on queue \(queueName)...")
-        let consumeStream = try await consumer.retryingConsume(retryInterval: retryInterval)
+        let consumeStream = try await consumer.retryingConsumeBuffer(retryInterval: retryInterval)
         return AnyAsyncSequence<RequestContext<T>>(
-            consumeStream.compactMap { message in
+            consumeStream.compactMap { buffer in
                 return try withSpan("\(T.self) consume", ofKind: .consumer) { span in
-                    let wrapper = try MassTransitWrapper(T.self, from: message)
+                    let wrapper = try MassTransitWrapper(T.self, from: buffer)
 
                     // Log!
                     logger.debug("Consumed message \(wrapper.message) from queue \(queueName)")
@@ -201,7 +201,7 @@ public struct MassTransit: Sendable {
         request.responseAddress = address
 
         // Start consuming before publishing request so we can get the response
-        let responseStream = try await consumer.consume()
+        let responseStream = try await consumer.consumeBuffer()
 
         // Send the request with a regular publish
         logger.info("Sending request of type \(T.self) to exchange \(exchangeName)...")

--- a/Sources/MassTransit/MassTransit.swift
+++ b/Sources/MassTransit/MassTransit.swift
@@ -22,7 +22,7 @@ public struct MassTransit: Sendable {
 
     public func send<T: MassTransitMessage>(
         _ value: T,
-        exchangeName: String = "\(T.self)",
+        exchangeName: String = String(describing: T.self),
         routingKey: String = ""
     ) async throws {
         let publisher = Publisher(
@@ -49,12 +49,10 @@ public struct MassTransit: Sendable {
 
     public func publish<T: MassTransitMessage>(
         _ value: T,
-        exchangeName: String = "\(T.self)",
+        exchangeName: String = String(describing: T.self),
         routingKey: String = "",
         retryInterval: Duration = MassTransitDefaultRetryInterval
-    )
-        async throws
-    {
+    ) async throws {
         let publisher = Publisher(
             rabbitMq, exchangeName, exchangeOptions: ExchangeOptions(type: .fanout, durable: true)
         )
@@ -79,13 +77,11 @@ public struct MassTransit: Sendable {
 
     public func consume<T: MassTransitMessage>(
         _: T.Type,
-        queueName: String = "\(T.self)-Consumer",
-        exchangeName: String = "\(T.self)",
+        queueName: String = "\(String(describing: T.self))-Consumer",
+        exchangeName: String = String(describing: T.self),
         routingKey: String = "",
         retryInterval: Duration = MassTransitDefaultRetryInterval
-    )
-        async throws -> AnyAsyncSequence<T>
-    {
+    ) async throws -> AnyAsyncSequence<T> {
         let consumer = Consumer(
             rabbitMq, queueName, exchangeName, routingKey,
             exchangeOptions: ExchangeOptions(type: .fanout, durable: true),
@@ -113,8 +109,8 @@ public struct MassTransit: Sendable {
 
     public func consumeWithContext<T: MassTransitMessage>(
         _: T.Type,
-        queueName: String = "\(T.self)-Consumer",
-        exchangeName: String = "\(T.self)",
+        queueName: String = "\(String(describing: T.self))-Consumer",
+        exchangeName: String = String(describing: T.self),
         routingKey: String = "",
         retryInterval: Duration = MassTransitDefaultRetryInterval
     )
@@ -153,7 +149,7 @@ public struct MassTransit: Sendable {
     public func request<T: MassTransitMessage, TResponse: MassTransitMessage>(
         _ value: T,
         _: TResponse.Type,
-        exchangeName: String = "\(T.self)",
+        exchangeName: String = String(describing: T.self),
         routingKey: String = "",
         timeout: Duration = MassTransitDefaultTimeout
     ) async throws -> TResponse {
@@ -176,7 +172,7 @@ public struct MassTransit: Sendable {
     private func performRequest<T: MassTransitMessage, TResponse: MassTransitMessage>(
         _ value: T,
         _: TResponse.Type,
-        _ exchangeName: String = "\(T.self)",
+        _ exchangeName: String = String(describing: T.self),
         _ routingKey: String = ""
     ) async throws -> TResponse {
         // Publisher is used to send the request

--- a/Sources/MassTransit/MassTransitWrapper.swift
+++ b/Sources/MassTransit/MassTransitWrapper.swift
@@ -18,6 +18,7 @@ extension MassTransitWrapper {
     init(_: T.Type, from buffer: ByteBuffer) throws {
         // Decode from JSON
         let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
         guard let wrapper = try? decoder.decode(Self.self, from: buffer)
         else {
             throw MassTransitError.parsingError
@@ -28,6 +29,7 @@ extension MassTransitWrapper {
     func jsonEncode() throws -> ByteBuffer {
         // Encode to JSON
         let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
         encoder.outputFormatting = [.prettyPrinted, .withoutEscapingSlashes]
         guard let json = try? encoder.encodeAsByteBuffer(self, allocator: .init())
         else {

--- a/Sources/MassTransit/MassTransitWrapper.swift
+++ b/Sources/MassTransit/MassTransitWrapper.swift
@@ -1,4 +1,6 @@
 import Foundation
+import NIOCore
+import NIOFoundationCompat
 
 public typealias MassTransitMessage = Codable & Sendable
 
@@ -13,28 +15,26 @@ struct MassTransitWrapper<T: MassTransitMessage>: MassTransitMessage {
 }
 
 extension MassTransitWrapper {
-    init(_: T.Type, from jsonString: String) throws {
+    init(_: T.Type, from buffer: ByteBuffer) throws {
         // Decode from JSON
         let decoder = JSONDecoder()
-        guard let data = jsonString.data(using: .utf8),
-            let wrapper = try? decoder.decode(Self.self, from: data)
+        guard let wrapper = try? decoder.decode(Self.self, from: buffer)
         else {
             throw MassTransitError.parsingError
         }
         self = wrapper
     }
 
-    func jsonEncode() throws -> String {
+    func jsonEncode() throws -> ByteBuffer {
         // Encode to JSON
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .withoutEscapingSlashes]
-        guard let json = try? encoder.encode(self),
-            let jsonString = String(data: json, encoding: .utf8)
+        guard let json = try? encoder.encodeAsByteBuffer(self, allocator: .init())
         else {
             throw MassTransitError.parsingError
         }
 
-        return jsonString
+        return json
     }
 
     static func create<TMessage: MassTransitMessage>(from value: TMessage, using exchangeName: String)


### PR DESCRIPTION
Also enable iso8601 date formatting for encoding/decoding which is used by the C# MassTransit library.